### PR TITLE
Add `BEDROCK_CONFIG` env var loading of config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-config-yaml ChangeLog
 
+## 4.1.0 - 2024-02-xx
+
+### Added:
+- Add support for loading a base64 encoded yaml config from `BEDROCK_CONFIG`
+  environment variable.
+
 ## 4.0.0 - 2022-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ another-bedrock-module:
   host: example.com
   port: 18443
 ```
+
+### Loading From Environment Variable
+It is possible to load the config YAML from a `BEDROCK_CONFIG` environment
+variable. The value is a base64 encoded version of the entire YAML config file.
+If this variable is found, the filesystem based config setup will be skipped.

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,8 @@ bedrock.events.on('bedrock.configure', function applyConfig() {
 
 // Exported for test purposes only
 export function _applyConfigFromEnv({configType}) {
-  logger.debug(`Attempting to apply the "${configType}" configuration from ` +
+  logger.debug(
+    `Attempting to apply the "${configType}" configuration from ` +
     `environment variable.`);
 
   const configYaml = jsYaml.safeLoad(

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,9 @@ bedrock.events.on('bedrock-cli.parsed', function applyConfig() {
     throw new Error('"bedrock-config-yaml" must be the last import.');
   }
 
-  _applyConfig({configType: 'core'});
+  if(!process.env.BEDROCK_CONFIG) {
+    _applyConfig({configType: 'core'});
+  }
 });
 
 bedrock.events.on('bedrock.configure', function applyConfig() {
@@ -31,8 +33,19 @@ bedrock.events.on('bedrock.configure', function applyConfig() {
     throw new Error('"bedrock-config-yaml" must be the last import.');
   }
 
-  _applyConfig({configType: 'app'});
+  if(process.env.BEDROCK_CONFIG) {
+    applyConfigFromEnv();
+  } else {
+    _applyConfig({configType: 'app'});
+  }
 });
+
+export function applyConfigFromEnv() {
+  const configYaml = jsYaml.load(
+    Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
+  );
+  _extend(true, config, configYaml);
+}
 
 function _applyConfig({configType}) {
   logger.debug(`Attempting to apply the "${configType}" configuration.`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,13 +34,14 @@ bedrock.events.on('bedrock.configure', function applyConfig() {
   }
 
   if(process.env.BEDROCK_CONFIG) {
-    applyConfigFromEnv();
+    _applyConfigFromEnv();
   } else {
     _applyConfig({configType: 'app'});
   }
 });
 
-export function applyConfigFromEnv() {
+// Exported for test purposes only
+export function _applyConfigFromEnv() {
   const configYaml = jsYaml.load(
     Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
   );

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,9 @@ bedrock.events.on('bedrock-cli.parsed', function applyConfig() {
     throw new Error('"bedrock-config-yaml" must be the last import.');
   }
 
-  if(!process.env.BEDROCK_CONFIG) {
+  if(process.env.BEDROCK_CONFIG) {
+    _applyConfigFromEnv({configType: 'core'});
+  } else {
     _applyConfig({configType: 'core'});
   }
 });
@@ -34,18 +36,24 @@ bedrock.events.on('bedrock.configure', function applyConfig() {
   }
 
   if(process.env.BEDROCK_CONFIG) {
-    _applyConfigFromEnv();
+    _applyConfigFromEnv({configType: 'app'});
   } else {
     _applyConfig({configType: 'app'});
   }
 });
 
 // Exported for test purposes only
-export function _applyConfigFromEnv() {
-  const configYaml = jsYaml.load(
+export function _applyConfigFromEnv({configType}) {
+  logger.debug(`Attempting to apply the "${configType}" configuration from ` +
+    `environment variable.`);
+
+  const configYaml = jsYaml.safeLoad(
     Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
   );
-  _extend(true, config, configYaml);
+  if(configYaml[configType]) {
+    logger.debug(`"${configType}" configuration found.`);
+    _extend(true, config, configYaml[configType]);
+  }
 }
 
 function _applyConfig({configType}) {

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {config} from '@bedrock/core';
-import {applyConfigFromEnv} from '@bedrock/config-yaml';
+import {_applyConfigFromEnv} from '@bedrock/config-yaml';
 
 describe('bedrock-config-yaml', () => {
   it('app yaml configuration should be merged into bedrock config', () => {
@@ -28,7 +28,8 @@ describe('bedrock-config-yaml', () => {
     process.env.BEDROCK_CONFIG = 'dGVzdC1iZWRyb2NrLWVudi15YW1sOgogIHRlc3RFb' +
       'nZWYWx1ZTogMTIzMTIzMTIzMTIz';
 
-    applyConfigFromEnv();
+    should.not.exist(config['test-bedrock-env-yaml']);
+    _applyConfigFromEnv();
 
     config['test-bedrock-env-yaml'].should.eql({
       testEnvValue: 123123123123

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -25,12 +25,21 @@ describe('bedrock-config-yaml', () => {
       .should.equal('FDRqpNJLVkgfVxPe');
   });
   it('configuration can be loaded via environment variable', async () => {
-    process.env.BEDROCK_CONFIG = 'dGVzdC1iZWRyb2NrLWVudi15YW1sOgogIHRlc3RFb' +
-      'nZWYWx1ZTogMTIzMTIzMTIzMTIz';
+    process.env.BEDROCK_CONFIG = 'YXBwOgogIHRlc3QtYmVkcm9jay1lbnYteWFtbDoKI' +
+      'CAgIHRlc3RFbnZWYWx1ZTogMTIzMTIzMTIzMTIzCmNvcmU6CiAgdGVzdC1jb3JlLWVud' +
+      'jogOTg3NTUzIA==';
 
     should.not.exist(config['test-bedrock-env-yaml']);
-    _applyConfigFromEnv();
+    should.not.exist(config['test-core-env']);
 
+    _applyConfigFromEnv({configType: 'core'});
+
+    should.not.exist(config['test-bedrock-env-yaml']);
+    config['test-core-env'].should.eql(987553);
+
+    _applyConfigFromEnv({configType: 'app'});
+
+    config['test-core-env'].should.eql(987553);
     config['test-bedrock-env-yaml'].should.eql({
       testEnvValue: 123123123123
     });

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {config} from '@bedrock/core';
+import {applyConfigFromEnv} from '@bedrock/config-yaml';
 
 describe('bedrock-config-yaml', () => {
   it('app yaml configuration should be merged into bedrock config', () => {
@@ -22,5 +23,15 @@ describe('bedrock-config-yaml', () => {
     config.loggers.console.someLoggerCombinedConfig.should.be.a('string');
     config.loggers.console.someLoggerCombinedConfig
       .should.equal('FDRqpNJLVkgfVxPe');
+  });
+  it('configuration can be loaded via environment variable', async () => {
+    process.env.BEDROCK_CONFIG = 'dGVzdC1iZWRyb2NrLWVudi15YW1sOgogIHRlc3RFb' +
+      'nZWYWx1ZTogMTIzMTIzMTIzMTIz';
+
+    applyConfigFromEnv();
+
+    config['test-bedrock-env-yaml'].should.eql({
+      testEnvValue: 123123123123
+    });
   });
 });


### PR DESCRIPTION
Add support for loading a base64 encoded yaml config from `BEDROCK_CONFIG` environment variable.