### PR TITLE
Update to `js-yaml@4`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-config-yaml ChangeLog
 
+## 4.3.0 - 2024-xx-xx
+
+### Changed
+- Update to `js-yaml@4`.
+
 ## 4.2.0 - 2024-02-28
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ export function _applyConfigFromEnv({configType}) {
     `Attempting to apply the "${configType}" configuration from ` +
     `environment variable.`);
 
-  const configYaml = jsYaml.safeLoad(
+  const configYaml = jsYaml.load(
     Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
   );
   if(configYaml[configType]) {
@@ -80,7 +80,7 @@ function _applyConfig({configType}) {
     const configFile = path.join(cfg[type].path, cfg[type].filename);
     if(fs.existsSync(configFile)) {
       logger.debug(`"${type}" configuration found "${configFile}".`);
-      let configYaml = jsYaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
+      let configYaml = jsYaml.load(fs.readFileSync(configFile, 'utf8'));
 
       // apply the combined config if it contains a section
       // that corresponds to `configType`

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-config-yaml",
   "dependencies": {
-    "js-yaml": "^3.14.1"
+    "js-yaml": "^4.1.0"
   },
   "peerDependencies": {
     "@bedrock/core": "^6.0.0"


### PR DESCRIPTION
Untested in apps.  See the migration notes.  If the breaking issues there are a significant concern, this could be made a breaking release too.
- https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md
- https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md

Some apps using this library are (were?) already using `js-yaml@4` directly leading to duplicate versions installed.