### PR TITLE
Update to `js-yaml@5`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-config-yaml ChangeLog
 
+## 4.5.0 - 2026-06-xx
+
+### Changed
+- Update dependencies:
+  - `js-yaml@5`
+    - Major update. See changelog and migration guide if needed. Simple YAML
+      likely requires no changes.
+
 ## 4.4.0 - 2026-06-23
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@
 
 import * as bedrock from '@bedrock/core';
 import fs from 'node:fs/promises';
-import jsYaml from 'js-yaml';
+import {load} from 'js-yaml';
 import {logger} from './logger.js';
 import path from 'node:path';
 
@@ -71,7 +71,7 @@ export function _applyConfigFromEnv({configType}) {
     `environment variable.`);
 
   try {
-    const configYaml = jsYaml.load(
+    const configYaml = load(
       Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
     );
     if(configYaml[configType]) {
@@ -116,7 +116,7 @@ export async function _applyConfig({configType}) {
 
       if(configExists) {
         logger.debug(`"${type}" configuration found "${configFile}".`);
-        let configYaml = jsYaml.load(content);
+        let configYaml = load(content);
 
         // apply the combined config if it contains a section
         // that corresponds to `configType`

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-config-yaml",
   "dependencies": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^5.1.0"
   },
   "peerDependencies": {
     "@bedrock/core": "^6.3.0"


### PR DESCRIPTION
- `js-yaml@5`
  - Major update. See changelog and migration guide if needed. Simple YAML likely requires no changes.
- https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md
- https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md

Are the above changes enough for a major version change?  I think basic YAML will be fine, unsure if anyone would be using advanced features in their configs that might cause issues.