### PR TITLE
Add BEDROCK_CONFIG_GZIP env var for compressed config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add support for loading the config from a `BEDROCK_CONFIG_GZIP` environment
   variable containing base64-encoded gzipped YAML. This allows deployments
   that store their config in a size-limited store (such as a 64 KB AWS Secrets
-  Manager secret) to gain roughly 4-6x headroom. Only one of
+  Manager secret) to gain roughly 3-4x headroom. Only one of
   `BEDROCK_CONFIG_GZIP` or `BEDROCK_CONFIG` may be set; setting both is
   ambiguous and throws. `BEDROCK_CONFIG_GZIP` is decoded strictly: a value
   that is not valid gzip fails loudly instead of falling back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # bedrock-config-yaml ChangeLog
 
+## 4.5.0 - 2026-07-dd
+
+### Added
+- Add support for loading the config from a `BEDROCK_CONFIG_GZIP` environment
+  variable containing base64-encoded gzipped YAML. This allows deployments
+  that store their config in a size-limited store (such as a 64 KB AWS Secrets
+  Manager secret) to gain roughly 4-6x headroom. `BEDROCK_CONFIG_GZIP` takes
+  precedence over `BEDROCK_CONFIG` when both are set, and is decoded strictly:
+  a value that is not valid gzip fails loudly instead of falling back to
+  `BEDROCK_CONFIG`. `BEDROCK_CONFIG` behavior is unchanged when
+  `BEDROCK_CONFIG_GZIP` is unset.
+
 ## 4.4.0 - 2026-06-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - Add support for loading the config from a `BEDROCK_CONFIG_GZIP` environment
   variable containing base64-encoded gzipped YAML. This allows deployments
   that store their config in a size-limited store (such as a 64 KB AWS Secrets
-  Manager secret) to gain roughly 4-6x headroom. `BEDROCK_CONFIG_GZIP` takes
-  precedence over `BEDROCK_CONFIG` when both are set, and is decoded strictly:
-  a value that is not valid gzip fails loudly instead of falling back to
+  Manager secret) to gain roughly 4-6x headroom. Only one of
+  `BEDROCK_CONFIG_GZIP` or `BEDROCK_CONFIG` may be set; setting both is
+  ambiguous and throws. `BEDROCK_CONFIG_GZIP` is decoded strictly: a value
+  that is not valid gzip fails loudly instead of falling back to
   `BEDROCK_CONFIG`. `BEDROCK_CONFIG` behavior is unchanged when
   `BEDROCK_CONFIG_GZIP` is unset.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The config YAML may also be loaded from a `BEDROCK_CONFIG_GZIP` environment
 variable. The value is the entire YAML config file, gzipped and then base64
 encoded. This is useful when the config is stored somewhere with a size limit,
 such as an AWS Secrets Manager secret, which caps a stored value at 64 KB;
-YAML and PEM text typically compress by roughly 4-6x.
+YAML and PEM text typically compress by roughly 3-4x.
 
 To produce a value:
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,32 @@ It is possible to load the config YAML from a `BEDROCK_CONFIG` environment
 variable. The value is a base64 encoded version of the entire YAML config file.
 If this variable is found, the filesystem based config setup will be skipped.
 
+### Loading From a Compressed Environment Variable
+
+The config YAML may also be loaded from a `BEDROCK_CONFIG_GZIP` environment
+variable. The value is the entire YAML config file, gzipped and then base64
+encoded. This is useful when the config is stored somewhere with a size limit,
+such as an AWS Secrets Manager secret, which caps a stored value at 64 KB;
+YAML and PEM text typically compress by roughly 4-6x.
+
+To produce a value:
+
+```
+gzip -c config.yaml | base64
+```
+
+To inspect one:
+
+```
+echo "$BEDROCK_CONFIG_GZIP" | base64 -d | gunzip
+```
+
+If both variables are set, `BEDROCK_CONFIG_GZIP` takes precedence. The value is
+decoded strictly: if `BEDROCK_CONFIG_GZIP` is set but is not valid gzip, startup
+fails with a `BEDROCK_CONFIG_GZIP is invalid` error rather than falling back to
+`BEDROCK_CONFIG`. When `BEDROCK_CONFIG_GZIP` is unset, `BEDROCK_CONFIG` behaves
+exactly as before.
+
 ## License
 
 [Apache License, Version 2.0](LICENSE) Copyright 2011-2024 Digital Bazaar, Inc.

--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ To inspect one:
 echo "$BEDROCK_CONFIG_GZIP" | base64 -d | gunzip
 ```
 
-If both variables are set, `BEDROCK_CONFIG_GZIP` takes precedence. The value is
-decoded strictly: if `BEDROCK_CONFIG_GZIP` is set but is not valid gzip, startup
-fails with a `BEDROCK_CONFIG_GZIP is invalid` error rather than falling back to
-`BEDROCK_CONFIG`. When `BEDROCK_CONFIG_GZIP` is unset, `BEDROCK_CONFIG` behaves
-exactly as before.
+Only one of `BEDROCK_CONFIG_GZIP` or `BEDROCK_CONFIG` may be set. Setting both
+is ambiguous and fails at startup rather than silently ignoring one of them.
+
+The value is decoded strictly: if `BEDROCK_CONFIG_GZIP` is set but is not valid
+gzip, startup fails with a `BEDROCK_CONFIG_GZIP is invalid` error rather than
+falling back to `BEDROCK_CONFIG`. When `BEDROCK_CONFIG_GZIP` is unset,
+`BEDROCK_CONFIG` behaves exactly as before.
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,12 +18,15 @@
 
 import * as bedrock from '@bedrock/core';
 import fs from 'node:fs/promises';
-import {gunzipSync} from 'node:zlib';
 import jsYaml from 'js-yaml';
 import {logger} from './logger.js';
 import path from 'node:path';
+import {promisify} from 'node:util';
+import zlib from 'node:zlib';
 
 import './config.js';
+
+const gunzip = promisify(zlib.gunzip);
 
 const {config} = bedrock;
 
@@ -38,7 +41,7 @@ bedrock.events.on('bedrock-cli.parsed', async function applyConfig() {
   }
 
   if(process.env.BEDROCK_CONFIG_GZIP || process.env.BEDROCK_CONFIG) {
-    _applyConfigFromEnv({configType: 'core'});
+    await _applyConfigFromEnv({configType: 'core'});
   } else {
     await _applyConfig({configType: 'core'});
   }
@@ -52,7 +55,7 @@ bedrock.events.on('bedrock.configure', async function applyConfig() {
   }
 
   if(process.env.BEDROCK_CONFIG_GZIP || process.env.BEDROCK_CONFIG) {
-    _applyConfigFromEnv({configType: 'app'});
+    await _applyConfigFromEnv({configType: 'app'});
   } else {
     await _applyConfig({configType: 'app'});
   }
@@ -68,33 +71,43 @@ function handleConfigLoadError({configType, message}) {
 /**
  * Reads the YAML config from the environment.
  *
- * `BEDROCK_CONFIG_GZIP` takes precedence when set; its value must be
- * base64-encoded gzipped YAML and is decoded strictly -- a value that is not
- * valid gzip throws rather than falling through to `BEDROCK_CONFIG`.
+ * Exactly one of `BEDROCK_CONFIG_GZIP` or `BEDROCK_CONFIG` may be set; the
+ * caller rejects the ambiguous case where both are present. When
+ * `BEDROCK_CONFIG_GZIP` is used, its value must be base64-encoded gzipped
+ * YAML and is decoded strictly -- a value that is not valid gzip rejects.
  * Otherwise `BEDROCK_CONFIG` is read as base64-encoded YAML.
  *
- * @returns {string} - The decoded YAML config.
+ * @returns {Promise<string>} - The decoded YAML config.
  */
-function _readConfigFromEnv() {
+async function _readConfigFromEnv() {
   if(process.env.BEDROCK_CONFIG_GZIP) {
     const buffer = Buffer.from(process.env.BEDROCK_CONFIG_GZIP, 'base64');
-    // throws if the value is not valid gzip
-    return gunzipSync(buffer).toString('utf8');
+    // rejects if the value is not valid gzip
+    return (await gunzip(buffer)).toString('utf8');
   }
   return Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString();
 }
 
 // Exported for test purposes only
-export function _applyConfigFromEnv({configType}) {
+export async function _applyConfigFromEnv({configType}) {
   logger.debug(
     `Attempting to apply the "${configType}" configuration from ` +
     `environment variable.`);
+
+  // setting both is ambiguous and most likely a deployment mistake; fail
+  // loudly rather than silently ignoring one of them
+  if(process.env.BEDROCK_CONFIG_GZIP && process.env.BEDROCK_CONFIG) {
+    handleConfigLoadError({
+      configType,
+      message: 'only one of BEDROCK_CONFIG_GZIP or BEDROCK_CONFIG may be set'
+    });
+  }
 
   const envVar = process.env.BEDROCK_CONFIG_GZIP ?
     'BEDROCK_CONFIG_GZIP' : 'BEDROCK_CONFIG';
 
   try {
-    const configYaml = jsYaml.load(_readConfigFromEnv());
+    const configYaml = jsYaml.load(await _readConfigFromEnv());
     if(configYaml[configType]) {
       logger.debug(`"${configType}" configuration found.`);
       _extend(true, config, configYaml[configType]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@
 
 import * as bedrock from '@bedrock/core';
 import fs from 'node:fs/promises';
+import {gunzipSync} from 'node:zlib';
 import jsYaml from 'js-yaml';
 import {logger} from './logger.js';
 import path from 'node:path';
@@ -36,7 +37,7 @@ bedrock.events.on('bedrock-cli.parsed', async function applyConfig() {
     throw new Error('"bedrock-config-yaml" must be the last import.');
   }
 
-  if(process.env.BEDROCK_CONFIG) {
+  if(process.env.BEDROCK_CONFIG_GZIP || process.env.BEDROCK_CONFIG) {
     _applyConfigFromEnv({configType: 'core'});
   } else {
     await _applyConfig({configType: 'core'});
@@ -50,7 +51,7 @@ bedrock.events.on('bedrock.configure', async function applyConfig() {
     throw new Error('"bedrock-config-yaml" must be the last import.');
   }
 
-  if(process.env.BEDROCK_CONFIG) {
+  if(process.env.BEDROCK_CONFIG_GZIP || process.env.BEDROCK_CONFIG) {
     _applyConfigFromEnv({configType: 'app'});
   } else {
     await _applyConfig({configType: 'app'});
@@ -64,22 +65,42 @@ function handleConfigLoadError({configType, message}) {
   throw new Error(`Failed to load config: ${message}`);
 }
 
+/**
+ * Reads the YAML config from the environment.
+ *
+ * `BEDROCK_CONFIG_GZIP` takes precedence when set; its value must be
+ * base64-encoded gzipped YAML and is decoded strictly -- a value that is not
+ * valid gzip throws rather than falling through to `BEDROCK_CONFIG`.
+ * Otherwise `BEDROCK_CONFIG` is read as base64-encoded YAML.
+ *
+ * @returns {string} - The decoded YAML config.
+ */
+function _readConfigFromEnv() {
+  if(process.env.BEDROCK_CONFIG_GZIP) {
+    const buffer = Buffer.from(process.env.BEDROCK_CONFIG_GZIP, 'base64');
+    // throws if the value is not valid gzip
+    return gunzipSync(buffer).toString('utf8');
+  }
+  return Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString();
+}
+
 // Exported for test purposes only
 export function _applyConfigFromEnv({configType}) {
   logger.debug(
     `Attempting to apply the "${configType}" configuration from ` +
     `environment variable.`);
 
+  const envVar = process.env.BEDROCK_CONFIG_GZIP ?
+    'BEDROCK_CONFIG_GZIP' : 'BEDROCK_CONFIG';
+
   try {
-    const configYaml = jsYaml.load(
-      Buffer.from(process.env.BEDROCK_CONFIG, 'base64').toString()
-    );
+    const configYaml = jsYaml.load(_readConfigFromEnv());
     if(configYaml[configType]) {
       logger.debug(`"${configType}" configuration found.`);
       _extend(true, config, configYaml[configType]);
     }
   } catch {
-    handleConfigLoadError({configType, message: 'BEDROCK_CONFIG is invalid'});
+    handleConfigLoadError({configType, message: `${envVar} is invalid`});
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bedrock/config-yaml",
-  "version": "4.5.0-0",
+  "version": "4.4.1-0",
   "type": "module",
   "description": "Bedrock Config YAML",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bedrock/config-yaml",
-  "version": "4.4.1-0",
+  "version": "4.5.0-0",
   "type": "module",
   "description": "Bedrock Config YAML",
   "license": "Apache-2.0",

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -19,6 +19,7 @@ import * as chai from 'chai';
 import {config, events, loggers} from '@bedrock/core';
 import {_applyConfigFromEnv} from '@bedrock/config-yaml';
 import chaiAsPromised from 'chai-as-promised';
+import {gzipSync} from 'node:zlib';
 import sinon from 'sinon';
 import winston from 'winston';
 
@@ -86,6 +87,108 @@ describe('bedrock-config-yaml', () => {
       testEnvValue: 123123123123
     });
   });
+  it('configuration can be loaded via gzip environment variable', async () => {
+    const gzipConfig = `
+    app:
+      test-bedrock-gzip-yaml:
+        testGzipValue: 123123123123
+    core:
+      test-core-gzip: 987553
+    `;
+
+    process.env.BEDROCK_CONFIG_GZIP =
+      gzipSync(Buffer.from(gzipConfig)).toString('base64');
+
+    try {
+      should.not.exist(config['test-bedrock-gzip-yaml']);
+      should.not.exist(config['test-core-gzip']);
+
+      _applyConfigFromEnv({configType: 'core'});
+
+      should.not.exist(config['test-bedrock-gzip-yaml']);
+      config['test-core-gzip'].should.eql(987553);
+
+      _applyConfigFromEnv({configType: 'app'});
+
+      config['test-core-gzip'].should.eql(987553);
+      config['test-bedrock-gzip-yaml'].should.eql({
+        testGzipValue: 123123123123
+      });
+    } finally {
+      delete process.env.BEDROCK_CONFIG_GZIP;
+    }
+  });
+  it('gzip environment variable takes precedence over BEDROCK_CONFIG',
+    async () => {
+      const gzipConfig = `
+      app:
+        test-bedrock-precedence: fromGzip
+      `;
+      const plainConfig = `
+      app:
+        test-bedrock-precedence: fromPlain
+      `;
+
+      process.env.BEDROCK_CONFIG_GZIP =
+        gzipSync(Buffer.from(gzipConfig)).toString('base64');
+      process.env.BEDROCK_CONFIG =
+        Buffer.from(plainConfig).toString('base64');
+
+      try {
+        await events.emit('bedrock.configure');
+      } finally {
+        delete process.env.BEDROCK_CONFIG_GZIP;
+        delete process.env.BEDROCK_CONFIG;
+      }
+
+      config['test-bedrock-precedence'].should.equal('fromGzip');
+    }
+  );
+  it('throws `BEDROCK_CONFIG_GZIP is invalid` error when value is not gzip',
+    async () => {
+      const plainConfig = `
+      app:
+        test-core-env: 987553
+      `;
+
+      // valid base64 of plain (non-gzipped) YAML; must not fall through
+      const loadBadConfigFn = async () => {
+        process.env.BEDROCK_CONFIG_GZIP =
+          Buffer.from(plainConfig).toString('base64');
+        return events.emit('bedrock.configure').finally(() => {
+          delete process.env.BEDROCK_CONFIG_GZIP;
+        });
+      };
+
+      await expect(loadBadConfigFn()).to.be.rejectedWith(Error,
+        'BEDROCK_CONFIG_GZIP is invalid'
+      );
+    }
+  );
+  it('does not expose data when a load from gzip env error throws',
+    async () => {
+      const duplicateKeyConfig = `
+      app:
+        sensitive: 1337
+        sensitive: hello-world
+      core:
+        test-core-env: 987553
+      `;
+
+      process.env.BEDROCK_CONFIG_GZIP =
+        gzipSync(Buffer.from(duplicateKeyConfig)).toString('base64');
+
+      let output = '';
+      await events.emit('bedrock.configure').catch(e => {
+        output = e.message;
+      }).finally(() => {
+        delete process.env.BEDROCK_CONFIG_GZIP;
+      });
+
+      expect(output).to.not.include('1337');
+      expect(output).to.not.include('hello-world');
+    }
+  );
   it('throws `BEDROCK_CONFIG is invalid` error when env config is invalid',
     async () => {
       const duplicateKeyConfig = `

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -19,11 +19,14 @@ import * as chai from 'chai';
 import {config, events, loggers} from '@bedrock/core';
 import {_applyConfigFromEnv} from '@bedrock/config-yaml';
 import chaiAsPromised from 'chai-as-promised';
-import {gzipSync} from 'node:zlib';
+import {promisify} from 'node:util';
 import sinon from 'sinon';
 import winston from 'winston';
+import zlib from 'node:zlib';
 
 chai.use(chaiAsPromised);
+
+const gzip = promisify(zlib.gzip);
 
 const {expect} = chai;
 
@@ -72,20 +75,24 @@ describe('bedrock-config-yaml', () => {
       'CAgIHRlc3RFbnZWYWx1ZTogMTIzMTIzMTIzMTIzCmNvcmU6CiAgdGVzdC1jb3JlLWVud' +
       'jogOTg3NTUzIA==';
 
-    should.not.exist(config['test-bedrock-env-yaml']);
-    should.not.exist(config['test-core-env']);
+    try {
+      should.not.exist(config['test-bedrock-env-yaml']);
+      should.not.exist(config['test-core-env']);
 
-    _applyConfigFromEnv({configType: 'core'});
+      await _applyConfigFromEnv({configType: 'core'});
 
-    should.not.exist(config['test-bedrock-env-yaml']);
-    config['test-core-env'].should.eql(987553);
+      should.not.exist(config['test-bedrock-env-yaml']);
+      config['test-core-env'].should.eql(987553);
 
-    _applyConfigFromEnv({configType: 'app'});
+      await _applyConfigFromEnv({configType: 'app'});
 
-    config['test-core-env'].should.eql(987553);
-    config['test-bedrock-env-yaml'].should.eql({
-      testEnvValue: 123123123123
-    });
+      config['test-core-env'].should.eql(987553);
+      config['test-bedrock-env-yaml'].should.eql({
+        testEnvValue: 123123123123
+      });
+    } finally {
+      delete process.env.BEDROCK_CONFIG;
+    }
   });
   it('configuration can be loaded via gzip environment variable', async () => {
     const gzipConfig = `
@@ -97,18 +104,18 @@ describe('bedrock-config-yaml', () => {
     `;
 
     process.env.BEDROCK_CONFIG_GZIP =
-      gzipSync(Buffer.from(gzipConfig)).toString('base64');
+      (await gzip(Buffer.from(gzipConfig))).toString('base64');
 
     try {
       should.not.exist(config['test-bedrock-gzip-yaml']);
       should.not.exist(config['test-core-gzip']);
 
-      _applyConfigFromEnv({configType: 'core'});
+      await _applyConfigFromEnv({configType: 'core'});
 
       should.not.exist(config['test-bedrock-gzip-yaml']);
       config['test-core-gzip'].should.eql(987553);
 
-      _applyConfigFromEnv({configType: 'app'});
+      await _applyConfigFromEnv({configType: 'app'});
 
       config['test-core-gzip'].should.eql(987553);
       config['test-bedrock-gzip-yaml'].should.eql({
@@ -118,30 +125,34 @@ describe('bedrock-config-yaml', () => {
       delete process.env.BEDROCK_CONFIG_GZIP;
     }
   });
-  it('gzip environment variable takes precedence over BEDROCK_CONFIG',
+  it('throws when both gzip and plain environment variables are set',
     async () => {
       const gzipConfig = `
       app:
-        test-bedrock-precedence: fromGzip
+        test-bedrock-both-set: fromGzip
       `;
       const plainConfig = `
       app:
-        test-bedrock-precedence: fromPlain
+        test-bedrock-both-set: fromPlain
       `;
 
-      process.env.BEDROCK_CONFIG_GZIP =
-        gzipSync(Buffer.from(gzipConfig)).toString('base64');
-      process.env.BEDROCK_CONFIG =
-        Buffer.from(plainConfig).toString('base64');
+      const loadBothFn = async () => {
+        process.env.BEDROCK_CONFIG_GZIP =
+          (await gzip(Buffer.from(gzipConfig))).toString('base64');
+        process.env.BEDROCK_CONFIG =
+          Buffer.from(plainConfig).toString('base64');
+        return events.emit('bedrock.configure').finally(() => {
+          delete process.env.BEDROCK_CONFIG_GZIP;
+          delete process.env.BEDROCK_CONFIG;
+        });
+      };
 
-      try {
-        await events.emit('bedrock.configure');
-      } finally {
-        delete process.env.BEDROCK_CONFIG_GZIP;
-        delete process.env.BEDROCK_CONFIG;
-      }
+      await expect(loadBothFn()).to.be.rejectedWith(Error,
+        'only one of BEDROCK_CONFIG_GZIP or BEDROCK_CONFIG may be set'
+      );
 
-      config['test-bedrock-precedence'].should.equal('fromGzip');
+      // neither config was applied
+      should.not.exist(config['test-bedrock-both-set']);
     }
   );
   it('throws `BEDROCK_CONFIG_GZIP is invalid` error when value is not gzip',
@@ -176,7 +187,7 @@ describe('bedrock-config-yaml', () => {
       `;
 
       process.env.BEDROCK_CONFIG_GZIP =
-        gzipSync(Buffer.from(duplicateKeyConfig)).toString('base64');
+        (await gzip(Buffer.from(duplicateKeyConfig))).toString('base64');
 
       let output = '';
       await events.emit('bedrock.configure').catch(e => {


### PR DESCRIPTION
## Summary

Adds support for loading the YAML config from a `BEDROCK_CONFIG_GZIP`
environment variable holding base64-encoded gzipped YAML.

Deployments that keep their config in a size-limited store — an AWS Secrets
Manager secret caps a stored value at 64 KB — can outgrow that limit. The
verbose YAML and PEM text these configs tend to hold compresses by roughly
3–4x, so gzipping the value buys substantial headroom without splitting the
config across multiple stores. Terraform can `base64gzip` on the way in, but
has no `base64gunzip`, so the decompression has to happen here.

## Design

- **Explicit variable, not byte-sniffing.** `BEDROCK_CONFIG_GZIP` declares
  intent rather than inferring the format from the content — a cleaner
  contract for a shared package.
- **Strict decode.** If `BEDROCK_CONFIG_GZIP` is set it is always gunzipped;
  a value that is not valid gzip throws and is surfaced through the existing
  `handleConfigLoadError` path, rather than silently falling back to
  `BEDROCK_CONFIG`.
- **Mutually exclusive.** Setting both `BEDROCK_CONFIG_GZIP` and
  `BEDROCK_CONFIG` is rejected with `only one of BEDROCK_CONFIG_GZIP or
  BEDROCK_CONFIG may be set`. There is no use case for supplying both, and
  silently ignoring one would hide what is most likely a deployment mistake.
  The check runs before the existing `try` block so it reports its own
  message rather than the generic `is invalid` error.
- **Async decompression.** Decoding uses `promisify(zlib.gunzip)` rather than
  `gunzipSync`, so config decompression does not block the event loop during
  startup. `_readConfigFromEnv` and `_applyConfigFromEnv` are async and both
  the `bedrock-cli.parsed` and `bedrock.configure` handlers await them, so a
  bad gzip value still fails startup instead of escaping as an unhandled
  rejection.
- **Backward compatible.** `BEDROCK_CONFIG` behavior is unchanged when the new
  variable is unset, so existing consumers are unaffected and the new path is
  opt-in per service.

The error message from `_applyConfigFromEnv` names whichever variable was
actually used, so a bad gzip value reports `BEDROCK_CONFIG_GZIP is invalid`
instead of misattributing the failure to `BEDROCK_CONFIG`.

`package.json` is intentionally left at `4.4.1-0`; the release tooling owns
the version bump. The CHANGELOG entry follows the existing convention of
naming the upcoming version with a `dd` day placeholder.

## Tests

Four cases added, all passing alongside the existing suite (12 total):

- gzip variable set and valid → parses to the expected config
- gzip variable set but not valid gzip → fails with `BEDROCK_CONFIG_GZIP is invalid`
- both variables set → fails with `only one of ... may be set`, and neither
  config is applied
- gzip load error → no config values leak into the error message

Tests use the async `zlib.gzip` to build fixtures. The pre-existing
`BEDROCK_CONFIG` plain-config test now cleans up the environment variable it
sets; it previously leaked into later tests, which the new mutual-exclusion
check surfaced.

Lint passes.
